### PR TITLE
fix: github repository env and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,10 +174,9 @@ Last Updated: `2023-06-22 18:25:15.707233069 +0000 UTC m=+0.079645794`
         if: ${{ needs.run-service-plan.result != 'success' }}
         run: exit 1
       - name: Analyze Terraform Plans
-        uses: u21/terraform-plan-analyzer/actions/analyze-plans@v1.2.0
         uses: u21-public/terraform-plan-analyzer/actions/analyze-plans@v0.6.0
         with:
-          gh_token: ${{ secrets.GH_ACTIONS_ACCESS_TOKEN }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
           version: "0.6.0"
 ```
 

--- a/README.md
+++ b/README.md
@@ -157,30 +157,28 @@ Last Updated: `2023-06-22 18:25:15.707233069 +0000 UTC m=+0.079645794`
           terraform show -json tfplan-${{ matrix.workspace }} > tfplan-${{ matrix.workspace }}.json
         shell: bash
       - name: Archive Plans
-        uses: actions/upload-artifact@v3
+        uses: u21-public/terraform-plan-analyzer/actions/archive-plans@v0.6.0
         with:
-          name: tfplans
-          path: |
-            tfplan-{{ matrix.workspace }}.json
+          plan_name: "tfplan-${{ matrix-planname }}"
 ```
 2) Unarchieve plans and analyze them 
 ```
   analyze-plans:
-    runs-on: ubuntu-latest
-    needs:[run-service-plan]
+    needs: [run-service-plan]
+    if: |
+      always()
+    runs-on: ${{ inputs.runner }}
+    name: Analyze Plans
     steps:
-      - name: download plans
-        uses: actions/download-artifact@v3
+      - name: Confirm Passing plans
+        if: ${{ needs.run-service-plan.result != 'success' }}
+        run: exit 1
+      - name: Analyze Terraform Plans
+        uses: u21/terraform-plan-analyzer/actions/analyze-plans@v1.2.0
+        uses: u21-public/terraform-plan-analyzer/actions/analyze-plans@v0.6.0
         with:
-          name: tfplans
-          path: tfplans
-      - name: Run Analyzer
-        shell: bash
-        run:|
-          docker run \
-            -v ./examples/:/examples \
-            ghcr.io/u21-public/terraform-plan-analyzer:0.4.0 \
-            --tfplans /examples/plans_json/basic_example
+          gh_token: ${{ secrets.GH_ACTIONS_ACCESS_TOKEN }}
+          version: "0.6.0"
 ```
 
 # Rendered Examples

--- a/actions/analyze-plans/action.yml
+++ b/actions/analyze-plans/action.yml
@@ -37,6 +37,6 @@ runs:
       run: |
         docker run \
           -v "$(pwd)/tfplans/:/tfplans" \
-          -e GITHUB_TOKEN -e GITHUB_OWNER -e GITHUB_PR_NUMBER --env GITHUB_REPOSTIRY=${{ env.GITHUB_REPO }}\
+          -e GITHUB_TOKEN -e GITHUB_OWNER -e GITHUB_PR_NUMBER --env GITHUB_REPOSITORY=${{ env.GITHUB_REPO }}\
           ghcr.io/u21-public/terraform-plan-analyzer:${{ env.VERSION }} \
           --tfplans /tfplans --github

--- a/actions/analyze-plans/action.yml
+++ b/actions/analyze-plans/action.yml
@@ -31,12 +31,12 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.gh_token }}
         GITHUB_OWNER: ${{ github.repository_owner }}
-        GITHUB_REPOSITORY: ${{ github.event.repository.name }}
+        GITHUB_REPO: ${{ github.event.repository.name }}
         GITHUB_PR_NUMBER: ${{ steps.get-pr-number.outputs.pr_number }}
         VERSION: ${{ inputs.version }}
       run: |
         docker run \
           -v "$(pwd)/tfplans/:/tfplans" \
-          -e GITHUB_TOKEN -e GITHUB_REPOSITORY -e GITHUB_OWNER -e GITHUB_PR_NUMBER \
+          -e GITHUB_TOKEN -e GITHUB_OWNER -e GITHUB_PR_NUMBER --env GITHUB_REPOSTIRY=${{ env.GITHUB_REPO }}\
           ghcr.io/u21-public/terraform-plan-analyzer:${{ env.VERSION }} \
           --tfplans /tfplans --github


### PR DESCRIPTION
update readme to use the action

update the action to set GITHUB_REPOSTIORY correctly. was setting with the org.


the issue with `-e GITHUB_REPOSTIORY` was its a default ENV that has org/repository, and we only want repository so gotta set it our selves