### PR TITLE
feat: add github actions tagging

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -57,6 +57,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: haya14busa/action-update-semver@v1
       - uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser


### PR DESCRIPTION
# Description

Use `- uses: haya14busa/action-update-semver@v1` to publish `v#` and `v#.#` tags when ever we release. easier to reference in github actions so people can pin to major versions or minor versions


# QA

Tested internally, but generally this action just works 