### PR TITLE
fix: don't add action block for workspace if no resources are unique

### DIFF
--- a/internal/plananalyzer/plan_analyzer_test.go
+++ b/internal/plananalyzer/plan_analyzer_test.go
@@ -79,7 +79,7 @@ func TestGenerateResourcesSomeUnique(t *testing.T) {
 
 	// Line is to long, so split it up
 	expected := "## Individual Workspaces\n### workspace1 :pencil2::wastebasket:\n"
-	expected = expected + "```diff\n+ To Create +\n```\n\n```diff\n- To Destroy -\n~ resource2\n```\n\n"
+	expected = expected + "```diff\n- To Destroy -\n~ resource2\n```\n\n"
 	result := planAnalyzer.generateResources()
 	assert.Equal(t, expected, result)
 }
@@ -255,7 +255,7 @@ func TestGenerateWorkspaceResourcesSomeUnique(t *testing.T) {
 		map[string][]string{Create: {"resource1"}},
 	}
 
-	expected := "### workspace1 :pencil2::wastebasket:\n```diff\n+ To Create +\n```\n\n```diff\n- To Destroy -\n~ resource2\n```\n\n"
+	expected := "### workspace1 :pencil2::wastebasket:\n```diff\n- To Destroy -\n~ resource2\n```\n\n"
 	result := planAnalyzer.GenerateWorkspaceResources("workspace1", changeSet)
 	assert.Equal(t, expected, result)
 }

--- a/internal/plananalyzer/plan_analyzer_test.go
+++ b/internal/plananalyzer/plan_analyzer_test.go
@@ -108,6 +108,97 @@ func TestGenerateResourcesMultipleWorkspaces(t *testing.T) {
 	assert.Equal(t, expected, result)
 }
 
+func TestGenerateWorkspaceResourcesMultipleWorkspacesSomeUnique(t *testing.T) {
+
+	var changeSetOne = map[string][]string{
+		Create: {"resource1"},
+	}
+
+	var changeSetTwo = map[string][]string{
+		Create: {"resource1"},
+		Update: {"resource2"},
+	}
+
+	planAnalyzer := &PlanAnalyzer{
+		[]PlanExtended{},
+		[][]string{{"Workspace", "To Create", "To Update", "To Destroy", "To Replace"}},
+		map[string]map[string][]string{
+			"workspace1": changeSetOne,
+			"workspace2": changeSetTwo,
+		},
+		map[string][]string{Create: {"resource1"}},
+	}
+
+	expectedOne := ""
+	expectedTwo := "### workspace2 :pencil2::fountain_pen:\n```diff\n! To Update !\n~ resource2\n```\n\n"
+
+	resultOne := planAnalyzer.GenerateWorkspaceResources("workspace1", changeSetOne)
+	resultTwo := planAnalyzer.GenerateWorkspaceResources("workspace2", changeSetTwo)
+
+	assert.Equal(t, expectedOne, resultOne)
+	assert.Equal(t, expectedTwo, resultTwo)
+}
+
+func TestGenerateWorkspaceResourcesMultipleWorkspacesNoUnique(t *testing.T) {
+
+	var changeSetOne = map[string][]string{
+		Create: {"resource1"},
+	}
+
+	var changeSetTwo = map[string][]string{
+		Create: {"resource1"},
+	}
+
+	planAnalyzer := &PlanAnalyzer{
+		[]PlanExtended{},
+		[][]string{{"Workspace", "To Create", "To Update", "To Destroy", "To Replace"}},
+		map[string]map[string][]string{
+			"workspace1": changeSetOne,
+			"workspace2": changeSetTwo,
+		},
+		map[string][]string{Create: {"resource1"}},
+	}
+
+	expectedOne := ""
+	expectedTwo := ""
+
+	resultOne := planAnalyzer.GenerateWorkspaceResources("workspace1", changeSetOne)
+	resultTwo := planAnalyzer.GenerateWorkspaceResources("workspace2", changeSetTwo)
+
+	assert.Equal(t, expectedOne, resultOne)
+	assert.Equal(t, expectedTwo, resultTwo)
+}
+
+func TestGenerateWorkspaceResourcesMultipleWorkspacesOnlyUnique(t *testing.T) {
+
+	var changeSetOne = map[string][]string{
+		Create: {"resource1"},
+	}
+
+	var changeSetTwo = map[string][]string{
+		Create: {"resource2"},
+	}
+
+	planAnalyzer := &PlanAnalyzer{
+		[]PlanExtended{},
+		[][]string{{"Workspace", "To Create", "To Update", "To Destroy", "To Replace"}},
+		map[string]map[string][]string{
+			"workspace1": changeSetOne,
+			"workspace2": changeSetTwo,
+		},
+		map[string][]string{},
+	}
+
+	expectedOne := "### workspace1 :pencil2:\n```diff\n+ To Create +\n~ resource1\n```\n\n"
+	expectedTwo := "### workspace2 :pencil2:\n```diff\n+ To Create +\n~ resource2\n```\n\n"
+
+	resultOne := planAnalyzer.GenerateWorkspaceResources("workspace1", changeSetOne)
+	resultTwo := planAnalyzer.GenerateWorkspaceResources("workspace2", changeSetTwo)
+
+	assert.Equal(t, expectedOne, resultOne)
+	assert.Equal(t, expectedTwo, resultTwo)
+}
+
 func TestGenerateWorkspaceResourcesNoUnique(t *testing.T) {
 
 	var changeSet = map[string][]string{

--- a/internal/plananalyzer/plan_analyzer_test.go
+++ b/internal/plananalyzer/plan_analyzer_test.go
@@ -102,8 +102,8 @@ func TestGenerateResourcesMultipleWorkspaces(t *testing.T) {
 
 	// Line is to long, so split it up
 	expected := "## Individual Workspaces\n### workspace1 :pencil2::wastebasket:\n"
-	expected = expected + "```diff\n+ To Create +\n```\n\n```diff\n- To Destroy -\n~ resource2\n```\n\n"
-	expected = expected + "### workspace2 :pencil2::wastebasket:\n```diff\n+ To Create +\n```\n\n```diff\n- To Destroy -\n~ resource2\n```\n\n"
+	expected = expected + "```diff\n- To Destroy -\n~ resource2\n```\n\n"
+	expected = expected + "### workspace2 :pencil2::wastebasket:\n```diff\n- To Destroy -\n~ resource2\n```\n\n"
 	result := planAnalyzer.generateResources()
 	assert.Equal(t, expected, result)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Run unit tests and ensure that they are passing
2. If your change introduces any API changes, make sure to update the e2e tests
3. Make sure documentation is updated for your PR!

-->

**What this PR does / why we need it**:
We are adding blank action blocks to the report when there are no unique changes . Here we track if a unique change was appeneded tot he report, if not, we dont add any block to the report.

Went this route vs adding a function called "hasUniqueChanges" as i want to avoid looping over the changes more, as that wont scale well with huge plans/lots of workspaces. Here we fix the bug while adding no extra looping 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #41

**How to manually test PR?**:
<!--
Explain how this PR can be pulled locally and tested manually.

Specify N/A if it's not relevant to the proposed changes.
-->

follow the steps in https://github.com/u21-public/terraform-plan-analyzer/issues/41 and confirm it fixes the issue 