### PR TITLE
fix: fix shared resources algorithm

### DIFF
--- a/internal/plananalyzer/plan_analyzer_test.go
+++ b/internal/plananalyzer/plan_analyzer_test.go
@@ -438,7 +438,7 @@ func TestProcessPlansSharedChanges(t *testing.T) {
 		{
 			tfjson.Plan{},
 			[]*tfjson.ResourceChange{},
-			[]string{},
+			[]string{"resource1"},
 			[]string{},
 			[]string{},
 			[]string{},
@@ -453,7 +453,7 @@ func TestProcessPlansSharedChanges(t *testing.T) {
 		map[string][]string{},
 	}
 	planAnalyzer.ProcessPlans()
-	result := map[string][]string{"Create": {}, "Destroy": {"resource1"}, "Replace": {}, "Update": {"resource1", "resource3"}}
+	result := map[string][]string{"Create": {}, "Destroy": {}, "Replace": {}, "Update": {"resource1"}}
 	assert.Equal(t, result, planAnalyzer.SharedChanges)
 }
 

--- a/internal/plananalyzer/plan_analyzer_test.go
+++ b/internal/plananalyzer/plan_analyzer_test.go
@@ -3,6 +3,7 @@ package plananalyzer
 import (
 	"testing"
 
+	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -295,4 +296,205 @@ func TestIsChangeUniqueNotUniqueEmptyUnique(t *testing.T) {
 	}
 	result := planAnalyzer.IsChangeUnique(Create, "resource1")
 	assert.Equal(t, true, result)
+}
+
+func TestProcessPlansSharedChangesNoShared(t *testing.T) {
+	plans := []PlanExtended{
+		{
+			tfjson.Plan{},
+			[]*tfjson.ResourceChange{},
+			[]string{"resource1"},
+			[]string{},
+			[]string{},
+			[]string{},
+			"workspaceOne",
+		},
+		{
+			tfjson.Plan{},
+			[]*tfjson.ResourceChange{},
+			[]string{"resource2"},
+			[]string{},
+			[]string{},
+			[]string{},
+			"workspaceTwo",
+		},
+	}
+
+	planAnalyzer := &PlanAnalyzer{
+		plans,
+		[][]string{{"Workspace", "To Create", "To Update", "To Destroy", "To Replace"}},
+		map[string]map[string][]string{},
+		map[string][]string{},
+	}
+	planAnalyzer.ProcessPlans()
+	result := map[string][]string(map[string][]string{"Create": {}, "Destroy": {}, "Replace": {}, "Update": {}})
+	assert.Equal(t, result, planAnalyzer.SharedChanges)
+}
+
+func TestProcessPlansSharedChangesOneShared(t *testing.T) {
+	plans := []PlanExtended{
+		{
+			tfjson.Plan{},
+			[]*tfjson.ResourceChange{},
+			[]string{"resource1"},
+			[]string{},
+			[]string{},
+			[]string{},
+			"workspaceOne",
+		},
+		{
+			tfjson.Plan{},
+			[]*tfjson.ResourceChange{},
+			[]string{"resource1"},
+			[]string{},
+			[]string{},
+			[]string{},
+			"workspaceTwo",
+		},
+	}
+
+	planAnalyzer := &PlanAnalyzer{
+		plans,
+		[][]string{{"Workspace", "To Create", "To Update", "To Destroy", "To Replace"}},
+		map[string]map[string][]string{},
+		map[string][]string{},
+	}
+	planAnalyzer.ProcessPlans()
+	result := map[string][]string(map[string][]string{"Create": {}, "Destroy": {}, "Replace": {}, "Update": {"resource1"}})
+	assert.Equal(t, result, planAnalyzer.SharedChanges)
+}
+
+func TestProcessPlansSharedChangesOneSharedAcrossMany(t *testing.T) {
+	plans := []PlanExtended{
+		{
+			tfjson.Plan{},
+			[]*tfjson.ResourceChange{},
+			[]string{"resource1", "resource2", "resource3"},
+			[]string{"resource2"},
+			[]string{"resource1"},
+			[]string{"resource1"},
+			"workspaceOne",
+		},
+		{
+			tfjson.Plan{},
+			[]*tfjson.ResourceChange{},
+			[]string{"resource1", "resource3"},
+			[]string{},
+			[]string{},
+			[]string{},
+			"workspaceTwo",
+		},
+		{
+			tfjson.Plan{},
+			[]*tfjson.ResourceChange{},
+			[]string{"resource3"},
+			[]string{},
+			[]string{},
+			[]string{},
+			"workspaceTwo",
+		},
+		{
+			tfjson.Plan{},
+			[]*tfjson.ResourceChange{},
+			[]string{"resource1", "resource3"},
+			[]string{},
+			[]string{},
+			[]string{},
+			"workspaceTwo",
+		},
+		{
+			tfjson.Plan{},
+			[]*tfjson.ResourceChange{},
+			[]string{"resource2", "resource3"},
+			[]string{},
+			[]string{"resource1"},
+			[]string{"resource4"},
+			"workspaceTwo",
+		},
+	}
+
+	planAnalyzer := &PlanAnalyzer{
+		plans,
+		[][]string{{"Workspace", "To Create", "To Update", "To Destroy", "To Replace"}},
+		map[string]map[string][]string{},
+		map[string][]string{},
+	}
+	planAnalyzer.ProcessPlans()
+	result := map[string][]string{"Create": {}, "Destroy": {}, "Replace": {}, "Update": {"resource3"}}
+	assert.Equal(t, result, planAnalyzer.SharedChanges)
+}
+
+func TestProcessPlansSharedChanges(t *testing.T) {
+	plans := []PlanExtended{
+		{
+			tfjson.Plan{},
+			[]*tfjson.ResourceChange{},
+			[]string{"resource1", "resource2", "resource3", "resource4"},
+			[]string{},
+			[]string{},
+			[]string{},
+			"workspaceOne",
+		},
+		{
+			tfjson.Plan{},
+			[]*tfjson.ResourceChange{},
+			[]string{},
+			[]string{},
+			[]string{},
+			[]string{},
+			"workspaceTwo",
+		},
+	}
+
+	planAnalyzer := &PlanAnalyzer{
+		plans,
+		[][]string{{"Workspace", "To Create", "To Update", "To Destroy", "To Replace"}},
+		map[string]map[string][]string{},
+		map[string][]string{},
+	}
+	planAnalyzer.ProcessPlans()
+	result := map[string][]string{"Create": {}, "Destroy": {"resource1"}, "Replace": {}, "Update": {"resource1", "resource3"}}
+	assert.Equal(t, result, planAnalyzer.SharedChanges)
+}
+
+func TestProcessPlansSharedPlansTwoSharedOneunique(t *testing.T) {
+	plans := []PlanExtended{
+		{
+			tfjson.Plan{},
+			[]*tfjson.ResourceChange{},
+			[]string{"resource1"},
+			[]string{},
+			[]string{},
+			[]string{},
+			"workspaceOne",
+		},
+		{
+			tfjson.Plan{},
+			[]*tfjson.ResourceChange{},
+			[]string{},
+			[]string{},
+			[]string{},
+			[]string{},
+			"workspaceTwo",
+		},
+		{
+			tfjson.Plan{},
+			[]*tfjson.ResourceChange{},
+			[]string{"resource1"},
+			[]string{},
+			[]string{},
+			[]string{},
+			"workspaceTwo",
+		},
+	}
+
+	planAnalyzer := &PlanAnalyzer{
+		plans,
+		[][]string{{"Workspace", "To Create", "To Update", "To Destroy", "To Replace"}},
+		map[string]map[string][]string{},
+		map[string][]string{},
+	}
+	planAnalyzer.ProcessPlans()
+	result := map[string][]string{"Create": {}, "Destroy": {}, "Replace": {}, "Update": {}}
+	assert.Equal(t, result, planAnalyzer.SharedChanges)
 }


### PR DESCRIPTION
`ProcessPlans` had a pretty big bug in it , in that how it "detects" shared resources between all workspaces was not working as intended.

We use hash lookup to save time looping between slices when we compare, however after the first loop we dont reset the hash to the new intersection.

This means we are essentially just running constant comparisons between the first plan in the list and the rest. Instead of a complete intersection of them ALL.

The fix is we reset the hash/intersection as we do the loop and generate a brand new intersection on each loop of it.

Added lots of tests to cover this.
<img width="688" alt="Screenshot 2023-07-12 at 12 13 06 PM" src="https://github.com/u21-public/terraform-plan-analyzer/assets/42545233/1e78f806-0207-4a37-9146-c7a16d1fe880">


# QA:
- comment out the change code (hash reset) and re run the tets suite and see how they fail now